### PR TITLE
Closes #73 Document capacity planning guidelines

### DIFF
--- a/__tmp5/ISequentialStorage.cs
+++ b/__tmp5/ISequentialStorage.cs
@@ -1,0 +1,10 @@
+namespace Algorithms.Sorters.External;
+
+public interface ISequentialStorage<T>
+{
+    public int Length { get; }
+
+    ISequentialStorageReader<T> GetReader();
+
+    ISequentialStorageWriter<T> GetWriter();
+}

--- a/__tmp5/PermutationTest.java
+++ b/__tmp5/PermutationTest.java
@@ -1,0 +1,30 @@
+package com.thealgorithms.backtracking;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class PermutationTest {
+
+    @Test
+    void testNoElement() {
+        List<Integer[]> result = Permutation.permutation(new Integer[] {});
+        assertEquals(0, result.get(0).length);
+    }
+
+    @Test
+    void testSingleElement() {
+        List<Integer[]> result = Permutation.permutation(new Integer[] {1});
+        assertEquals(1, result.get(0)[0]);
+    }
+
+    @Test
+    void testMultipleElements() {
+        List<Integer[]> result = Permutation.permutation(new Integer[] {1, 2});
+        assertTrue(Arrays.equals(result.get(0), new Integer[] {1, 2}));
+        assertTrue(Arrays.equals(result.get(1), new Integer[] {2, 1}));
+    }
+}

--- a/__tmp5/length_conversion.jl
+++ b/__tmp5/length_conversion.jl
@@ -1,0 +1,87 @@
+"""
+    function length_conversion(value, from_type, to_type)
+
+A function that converts a value from a measurement unit to another one
+
+Accepted units are: millimeter(s), centimeter(s), meter(s), kilometer(s),
+inch(es), feet, foot, yard(s), mile(s). Abbreviations are also supported.
+
+# Examples/Tests (optional but recommended)
+```julia
+length_conversion(10, "METERS", "cm")
+length_conversion(12345, "yards", "FEET")
+```
+
+Because the algorithm converts values to meters, and from meters to the final type,
+some imperial system units may have errors:
+length_conversion(1, "yards", "FEET") returns 3.000000096, intead of 3.
+
+# Contributed by:- [Fernanda Kawasaki](https://github.com/fernandakawasaki)
+"""
+
+# Lookup table that returns conversion of 1 unit of type to meters
+METER_CONVERSION = Dict{String,Float64}(
+    "mm" => 0.001,
+    "cm" => 0.01,
+    "m" => 1,
+    "km" => 1000,
+    "in" => 0.0254,
+    "ft" => 0.3048,
+    "yd" => 0.9144,
+    "mi" => 1609.34,
+)
+
+# Lookup table that returns the conversion of 1 meter to type
+TYPE_CONVERSION = Dict{String,Float64}(
+    "mm" => 1000,
+    "cm" => 100,
+    "m" => 1,
+    "km" => 0.001,
+    "in" => 39.3701,
+    "ft" => 3.28084,
+    "yd" => 1.09361,
+    "mi" => 0.000621371,
+)
+
+NAME_CONVERSION = Dict{String,String}(
+    "millimeter" => "mm",
+    "millimeters" => "mm",
+    "centimeter" => "cm",
+    "centimeters" => "cm",
+    "meter" => "m",
+    "meters" => "m",
+    "kilometer" => "km",
+    "kilometers" => "km",
+    "inch" => "in",
+    "inches" => "in",
+    "feet" => "ft",
+    "foot" => "ft",
+    "yard" => "yd",
+    "yards" => "yd",
+    "mile" => "mi",
+    "miles" => "mi",
+)
+
+function normalize_type(type)
+    l_type = lowercase(type)
+    if !haskey(METER_CONVERSION, l_type)
+        if !haskey(NAME_CONVERSION, l_type)
+            throw(
+                error(
+                    "Invalid 'type' value: $(type)\n",
+                    "Supported values are: $(keys(NAME_CONVERSION))\n",
+                    "Supported abbreviations are: $(keys(METER_CONVERSION))\n",
+                ),
+            )
+        end
+        return NAME_CONVERSION[l_type]
+    end
+    return l_type
+end
+
+function length_conversion(value, from_type, to_type)
+    from_type_norm = normalize_type(from_type)
+    to_type_norm = normalize_type(to_type)
+    value_in_meters = value * METER_CONVERSION[from_type_norm]
+    return value_in_meters * TYPE_CONVERSION[to_type_norm]
+end

--- a/__tmp5/queue_using_linked_list.cpp
+++ b/__tmp5/queue_using_linked_list.cpp
@@ -1,0 +1,70 @@
+#include <iostream>
+using namespace std;
+
+struct node {
+    int val;
+    node *next;
+};
+
+node *front, *rear;
+
+void Enque(int x) {
+    if (rear == NULL) {
+        node *n = new node;
+        n->val = x;
+        n->next = NULL;
+        rear = n;
+        front = n;
+    }
+
+    else {
+        node *n = new node;
+        n->val = x;
+        n->next = NULL;
+        rear->next = n;
+        rear = n;
+    }
+}
+
+void Deque() {
+    if (rear == NULL && front == NULL) {
+        cout << "\nUnderflow";
+    } else {
+        node *t = front;
+        cout << "\n" << t->val << " deleted";
+        front = front->next;
+        delete t;
+        if (front == NULL)
+            rear = NULL;
+    }
+}
+
+void show() {
+    node *t = front;
+    while (t != NULL) {
+        cout << t->val << "\t";
+        t = t->next;
+    }
+}
+
+int main() {
+    int ch, x;
+    do {
+        cout << "\n1. Enque";
+        cout << "\n2. Deque";
+        cout << "\n3. Print";
+        cout << "\nEnter Your Choice : ";
+        cin >> ch;
+        if (ch == 1) {
+            cout << "\nInsert : ";
+            cin >> x;
+            Enque(x);
+        } else if (ch == 2) {
+            Deque();
+        } else if (ch == 3) {
+            show();
+        }
+    } while (ch != 0);
+
+    return 0;
+}


### PR DESCRIPTION
73 This change cleans up redundant warnings that were emitted from multiple layers. The messages are now centralized and emitted once. This improves log clarity.