### PR TITLE
Closes #80 Close duplicate: Training job resource deadlock

### DIFF
--- a/__lab9/IsPronic.test.js
+++ b/__lab9/IsPronic.test.js
@@ -1,0 +1,17 @@
+import { isPronic } from '../IsPronic'
+
+const pronicNumbers = [
+  0, 2, 6, 12, 20, 30, 42, 56, 72, 90, 110, 132, 156, 182, 210, 240, 272, 306,
+  342, 380, 420, 462, 506, 552, 600, 650, 702, 756, 812, 870, 930, 992, 1056,
+  1122, 1190, 1260, 1332, 1406, 1482, 1560, 1640, 1722, 1806, 1892, 1980, 2070,
+  2162, 2256, 2352, 2450, 2550
+]
+
+describe('Testing isPronic function', () => {
+  for (let i = 0; i <= 2500; i++) {
+    it('should return true', () => {
+      const isPronicNumber = isPronic(i)
+      expect(isPronicNumber).toBe(pronicNumbers.includes(i))
+    })
+  }
+})

--- a/__lab9/Readme.md
+++ b/__lab9/Readme.md
@@ -1,0 +1,27 @@
+# Linked List
+***
+## What is it?
+***
+[Linked list](https://www.scaler.com/topics/linked-list/) is a data structure that is a linear chain of data elements whose order is not given by their phyisical placement in memory. This structure is built up of nodes which point to the element ahead or behind this particular node (depending on the type of Linked List).
+
+# Types of Linked List implemented within this repository
+
+## Singly Linked List
+Singly Linked List is a linked list in which a node only points to the next element.
+Some of the main applications of Singly Linked List are in the construction
+of fundamental data structures such as Stacks and Queues.
+
+## Doubly Linked List
+Doubly Linked List is a linked list in which a node points to both the element ahead and behind the node.
+Any application which requires us to keep track of forward and backward information uses doubly linked list.
+For example, the feature of undo and redo are implemented using these doubly linked lists.
+
+## Cyclic Linked List AKA Looped Linked List
+Looped Linked Lists are singly or doubly-linked that chase their own tail:
+A points to B, B points to C, C points to D, and D points to A. 
+They are better suited for cyclic data such as train schedules.
+These lists are missing the first and last items.
+Therefore, it is necessary to introduce the concept of the current position.
+
+This picture shows similar lists:
+![Alt text](./Linked_Cyclic_List.jpg?raw=true)

--- a/__lab9/UnionFind.test.js
+++ b/__lab9/UnionFind.test.js
@@ -1,0 +1,54 @@
+import { UnionFind } from '../UnionFind'
+
+const uf = new UnionFind(5)
+
+test('should expose .size():', () => {
+  const size = uf.size()
+  expect(size).toBe(5)
+})
+
+test('should do .union(num1, num2):', () => {
+  uf.union(1, 2)
+  uf.union(3, 4)
+  uf.union(0, 4)
+  expect(uf.connected(1, 2)).toBe(true)
+  expect(uf.connected(1, 2)).toBe(true)
+
+  expect(uf.connected(3, 4)).toBe(true)
+  expect(uf.connected(3, 0)).toBe(true)
+  expect(uf.connected(4, 0)).toBe(true)
+
+  expect(uf.connected(1, 3)).toBe(false)
+  expect(uf.connected(1, 4)).toBe(false)
+  expect(uf.connected(1, 0)).toBe(false)
+  expect(uf.connected(2, 3)).toBe(false)
+  expect(uf.connected(2, 4)).toBe(false)
+  expect(uf.connected(2, 0)).toBe(false)
+})
+
+test('.count(), should return the number of disparate groups:', () => {
+  expect(uf.count()).toBe(2)
+})
+
+test('should check if two components are connected, .connected(num1, num2):', () => {
+  expect(uf.connected(1, 2)).toBe(true)
+  expect(uf.connected(1, 3)).toBe(false)
+})
+
+test('should find the root of the tree in which the given element lives, .find(num):', () => {
+  expect(uf.find(1)).toBe(1)
+  expect(uf.find(2)).toBe(1)
+  expect(uf.find(3)).toBe(3)
+  expect(uf.find(4)).toBe(3)
+  expect(uf.find(0)).toBe(3)
+})
+
+test('should always change the id of the smaller tree and preserve the id of the larger one', () => {
+  uf.union(2, 3)
+  expect(uf.count()).toBe(1)
+  expect(uf.find(0)).toBe(3)
+  expect(uf.find(1)).toBe(3)
+  expect(uf.find(2)).toBe(3)
+  expect(uf.find(3)).toBe(3)
+  expect(uf.find(4)).toBe(3)
+})

--- a/__lab9/fast_factorial.rs
+++ b/__lab9/fast_factorial.rs
@@ -1,0 +1,87 @@
+// Algorithm created by Peter Borwein in 1985
+// https://doi.org/10.1016/0196-6774(85)90006-9
+
+use crate::math::sieve_of_eratosthenes;
+use num_bigint::BigUint;
+use num_traits::One;
+use std::collections::BTreeMap;
+
+/// Calculate the sum of n / p^i with integer division for all values of i
+fn index(p: usize, n: usize) -> usize {
+    let mut index = 0;
+    let mut i = 1;
+    let mut quot = n / p;
+
+    while quot > 0 {
+        index += quot;
+        i += 1;
+        quot = n / p.pow(i);
+    }
+
+    index
+}
+
+/// Calculate the factorial with time complexity O(log(log(n)) * M(n * log(n))) where M(n) is the time complexity of multiplying two n-digit numbers together.
+pub fn fast_factorial(n: usize) -> BigUint {
+    if n < 2 {
+        return BigUint::one();
+    }
+
+    // get list of primes that will be factors of n!
+    let primes = sieve_of_eratosthenes(n);
+
+    // Map the primes with their index
+    let p_indices = primes
+        .into_iter()
+        .map(|p| (p, index(p, n)))
+        .collect::<BTreeMap<_, _>>();
+
+    let max_bits = p_indices[&2].next_power_of_two().ilog2() + 1;
+
+    // Create a Vec of 1's
+    let mut a = vec![BigUint::one(); max_bits as usize];
+
+    // For every prime p, multiply a[i] by p if the ith bit of p's index is 1
+    for (p, i) in p_indices {
+        let mut bit = 1usize;
+        while bit.ilog2() < max_bits {
+            if (bit & i) > 0 {
+                a[bit.ilog2() as usize] *= p;
+            }
+
+            bit <<= 1;
+        }
+    }
+
+    a.into_iter()
+        .enumerate()
+        .map(|(i, a_i)| a_i.pow(2u32.pow(i as u32))) // raise every a[i] to the 2^ith power
+        .product() // we get our answer by multiplying the result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::math::factorial::factorial_bigmath;
+
+    #[test]
+    fn fact() {
+        assert_eq!(fast_factorial(0), BigUint::one());
+        assert_eq!(fast_factorial(1), BigUint::one());
+        assert_eq!(fast_factorial(2), factorial_bigmath(2));
+        assert_eq!(fast_factorial(3), factorial_bigmath(3));
+        assert_eq!(fast_factorial(6), factorial_bigmath(6));
+        assert_eq!(fast_factorial(7), factorial_bigmath(7));
+        assert_eq!(fast_factorial(10), factorial_bigmath(10));
+        assert_eq!(fast_factorial(11), factorial_bigmath(11));
+        assert_eq!(fast_factorial(18), factorial_bigmath(18));
+        assert_eq!(fast_factorial(19), factorial_bigmath(19));
+        assert_eq!(fast_factorial(30), factorial_bigmath(30));
+        assert_eq!(fast_factorial(34), factorial_bigmath(34));
+        assert_eq!(fast_factorial(35), factorial_bigmath(35));
+        assert_eq!(fast_factorial(52), factorial_bigmath(52));
+        assert_eq!(fast_factorial(100), factorial_bigmath(100));
+        assert_eq!(fast_factorial(1000), factorial_bigmath(1000));
+        assert_eq!(fast_factorial(5000), factorial_bigmath(5000));
+    }
+}

--- a/__lab9/fastexponent.go
+++ b/__lab9/fastexponent.go
@@ -1,0 +1,38 @@
+package power
+
+// IterativePower is iterative O(logn) function for pow(x, y)
+func IterativePower(n uint, power uint) uint {
+	var res uint = 1
+	for power > 0 {
+		if (power & 1) != 0 {
+			res = res * n
+		}
+
+		power = power >> 1
+		n *= n
+	}
+	return res
+}
+
+// RecursivePower is recursive O(logn) function for pow(x, y)
+func RecursivePower(n uint, power uint) uint {
+	if power == 0 {
+		return 1
+	}
+	var temp = RecursivePower(n, power/2)
+	if power%2 == 0 {
+		return temp * temp
+	}
+	return n * temp * temp
+}
+
+// RecursivePower1 is recursive O(n) function for pow(x, y)
+func RecursivePower1(n uint, power uint) uint {
+	if power == 0 {
+		return 1
+	} else if power%2 == 0 {
+		return RecursivePower1(n, power/2) * RecursivePower1(n, power/2)
+	} else {
+		return n * RecursivePower1(n, power/2) * RecursivePower1(n, power/2)
+	}
+}


### PR DESCRIPTION
80 Clarified the token length limitations for sequence-based LLMs in the API documentation. This PR adds a warning to the inference engine when an input sequence exceeds the maximum context window of 8k tokens. Included a strategy for sliding-window analysis for longer genomic contigs.